### PR TITLE
Make operator<< inline

### DIFF
--- a/smartenum.hpp
+++ b/smartenum.hpp
@@ -119,7 +119,7 @@ namespace smart_enum
         return Type##_enum_names.at((int32_t)value);\
     } \
     \
-    std::ostream& operator<<(std::ostream& outStream, Type value)\
+    inline std::ostream& operator<<(std::ostream& outStream, Type value)\
     {\
         outStream << to_string(value);\
         return outStream;\


### PR DESCRIPTION
Just like to_string, operator<< needs to be declared inline. If this is not the case, multiple translation units may have the same definition of operator<< and they will not be able to be linked together.
