### PR TITLE
Support for hex literals

### DIFF
--- a/smartenum.hpp
+++ b/smartenum.hpp
@@ -58,7 +58,7 @@ namespace smart_enum
             if(equalSignPos != std::string::npos)
             {
                 std::string rightHandSide = currentEnumEntry.substr(equalSignPos + 1);
-                currentEnumValue = std::stoi(rightHandSide);
+                currentEnumValue = std::stoi(rightHandSide, 0, 0);
                 currentEnumEntry.erase(equalSignPos);
             }
     
@@ -86,7 +86,7 @@ namespace smart_enum
             if(equalSignPos != std::string::npos)
             {
                 std::string rightHandSide = currentEnumEntry.substr(equalSignPos + 1);
-                currentEnumValue = std::stoi(rightHandSide);
+                currentEnumValue = std::stoi(rightHandSide, 0, 0);
                 currentEnumEntry.erase(equalSignPos);
             }
     


### PR DESCRIPTION
Setting the base value for stoi to 0 (default is 10) allows hex literals to be used as enum values.

I've added support for binary literals and specifying the enum's underlying type in my own copy since I needed it but it's a little bit dirty so I won't open a pull request for those additions. If you're interested though, my own copy is at:
https://github.com/EmberEmu/Ember/blob/spark-new/src/libs/shared/shared/smartenum.hpp

The end result is that this is possible:

``` cpp
smart_enum_class(Days, uint8_t, Monday = 0b10, Tuesday)
```

Thanks! :+1: 
